### PR TITLE
Fix webauthn authn javascript in DefaultLoginPageGeneratingFilter

### DIFF
--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -400,19 +400,6 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 				// FIXME: Use https://www.w3.org/TR/webauthn-3/#sctn-parseRequestOptionsFromJSON
 				options.challenge = base64url.decode(options.challenge);
 
-			function setup() {
-
-				// <button>
-				const passkeySignin = document.getElementById('passkey-signin');
-
-				// Start authentication when the user clicks a button
-				passkeySignin.addEventListener('click', async () => {
-					// FIXME: add contextRoot
-					const optionsResponse = await fetch('/webauthn/authenticate/options');
-					const options = await optionsResponse.json();
-					// FIXME: Use https://www.w3.org/TR/webauthn-3/#sctn-parseRequestOptionsFromJSON
-					options.challenge = base64url.decode(options.challenge);
-
 				// Invoke the WebAuthn get() method.
 				const credentialOptions = {
 					publicKey: options,


### PR DESCRIPTION
The default login page threw the following JS exception in Chrome, even without interacting with the page.

```
Uncaught SyntaxError: missing ) after argument list
login:131
```

It seems there are remnants of an old `setup` function breaking the code.

There's probably a test to write for this, I'll take a look later if I can find the  time.