### PR TITLE
Fix conditional mediation

### DIFF
--- a/spring-security-javascript/build.gradle
+++ b/spring-security-javascript/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 tasks.named('check') {
-    dependsOn 'npm_run_test'
+    dependsOn 'npm_run_check'
 }
 
 tasks.register('dist', Zip) {

--- a/spring-security-javascript/lib/abort-controller.js
+++ b/spring-security-javascript/lib/abort-controller.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+const holder = {
+  controller: new AbortController(),
+};
+
+/**
+ * Returns a new AbortSignal to be used in the options for the registration and authentication ceremonies.
+ * Aborts the existing AbortController if it exists, cancelling any existing ceremony.
+ *
+ * The authentication ceremony, when triggered with conditional mediation, shows a non-modal
+ * interaction. If the user does not interact with the non-modal dialog, the existing ceremony MUST
+ * be cancelled before initiating a new one, hence the need for a singleton AbortController.
+ *
+ * @returns {AbortSignal} a new, non-aborted AbortSignal
+ */
+function newSignal() {
+  if (!!holder.controller) {
+    holder.controller.abort("Initiating new WebAuthN ceremony, cancelling current ceremony");
+  }
+  holder.controller = new AbortController();
+  return holder.controller.signal;
+}
+
+export default {
+  newSignal,
+};

--- a/spring-security-javascript/lib/webauthn-core.js
+++ b/spring-security-javascript/lib/webauthn-core.js
@@ -18,6 +18,7 @@
 
 import base64url from "./base64url.js";
 import http from "./http.js";
+import abortController from "./abort-controller.js";
 
 async function isConditionalMediationAvailable() {
   return !!(
@@ -28,7 +29,6 @@ async function isConditionalMediationAvailable() {
 }
 
 async function authenticate(headers, contextPath, useConditionalMediation) {
-  const abortController = new AbortController();
   // FIXME: add contextRoot
   const options = await http.post(`${contextPath}/webauthn/authenticate/options`, headers).then((r) => r.json());
   // FIXME: Use https://www.w3.org/TR/webauthn-3/#sctn-parseRequestOptionsFromJSON
@@ -37,7 +37,7 @@ async function authenticate(headers, contextPath, useConditionalMediation) {
   // Invoke the WebAuthn get() method.
   const credentialOptions = {
     publicKey: decodedOptions,
-    signal: abortController.signal,
+    signal: abortController.newSignal(),
   };
   if (useConditionalMediation) {
     // Request a conditional UI
@@ -109,6 +109,7 @@ async function register(headers, contextPath, label) {
   const credentialsContainer = await navigator.credentials
     .create({
       publicKey: decodedOptions,
+      signal: abortController.newSignal(),
     })
     .catch((e) => {
       throw new Error("Registration failed: " + e.message, { cause: e });

--- a/spring-security-javascript/lib/webauthn-login.js
+++ b/spring-security-javascript/lib/webauthn-login.js
@@ -27,9 +27,9 @@ async function conditionalMediation(headers, contextPath) {
 }
 
 export async function setupLogin(headers, contextPath, signinButton) {
-  await conditionalMediation(headers, contextPath);
-
   signinButton.addEventListener("click", async () => {
     await webauthn.authenticate(headers, contextPath, false);
   });
+
+  await conditionalMediation(headers, contextPath);
 }

--- a/spring-security-javascript/lib/webauthn-registration.js
+++ b/spring-security-javascript/lib/webauthn-registration.js
@@ -73,10 +73,12 @@ export async function setupRegistration(headers, contextPath, ui) {
     }
   });
 
-  ui.getDeleteForms().forEach((form) => form.addEventListener('submit', async function (e) {
-    e.preventDefault()
-    submitDeleteForm(contextPath, form, headers)
-  }));
+  ui.getDeleteForms().forEach((form) =>
+    form.addEventListener("submit", async function (e) {
+      e.preventDefault();
+      submitDeleteForm(contextPath, form, headers);
+    }),
+  );
 }
 
 async function submitDeleteForm(contextPath, form, headers) {
@@ -86,8 +88,8 @@ async function submitDeleteForm(contextPath, form, headers) {
       "Content-Type": "application/json",
       ...headers,
     },
-  }
+  };
   await fetch(form.action, options);
   window.location.href = `${contextPath}/webauthn/register?success`;
-  return false
+  return false;
 }

--- a/spring-security-javascript/package.json
+++ b/spring-security-javascript/package.json
@@ -17,9 +17,10 @@
   },
   "scripts": {
     "test": "mocha",
+    "check": "npm test && npm run lint",
     "test:watch": "mocha --watch --parallel",
     "assemble": "esbuild lib/index.js --bundle --outfile=build/dist/spring-security-webauthn.js",
-    "build": "npm test && npm run lint && npm run assemble",
+    "build": "npm run check && npm run assemble",
     "lint": "eslint",
     "format": "npm run lint -- --fix"
   },

--- a/spring-security-javascript/test/abort-controller.test.js
+++ b/spring-security-javascript/test/abort-controller.test.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+import abortController from "../lib/abort-controller.js";
+import { expect } from "chai";
+
+describe("abort-controller", () => {
+  describe("newSignal", () => {
+    it("returns an AbortSignal", () => {
+      const signal = abortController.newSignal();
+
+      expect(signal).to.be.instanceof(AbortSignal);
+      expect(signal.aborted).to.be.false;
+    });
+
+    it("returns a new signal every time", () => {
+      const initialSignal = abortController.newSignal();
+
+      const newSignal = abortController.newSignal();
+
+      expect(initialSignal).to.not.equal(newSignal);
+    });
+
+    it("aborts the existing signal", () => {
+      const signal = abortController.newSignal();
+
+      abortController.newSignal();
+
+      expect(signal.aborted).to.be.true;
+      expect(signal.reason).to.equal("Initiating new WebAuthN ceremony, cancelling current ceremony");
+    });
+  });
+});

--- a/spring-security-javascript/test/webauthn-core.test.js
+++ b/spring-security-javascript/test/webauthn-core.test.js
@@ -56,14 +56,14 @@ describe("webauthn-core", () => {
         global.window = {};
         const result = await webauthn.isConditionalMediationAvailable();
         expect(result).to.be.false;
-      })
+      });
       it("PublicKeyCredential.isConditionalMediationAvailable undefined", async () => {
         global.window = {
           PublicKeyCredential: {},
         };
         const result = await webauthn.isConditionalMediationAvailable();
         expect(result).to.be.false;
-      })
+      });
       it("PublicKeyCredential.isConditionalMediationAvailable false", async () => {
         global.window = {
           PublicKeyCredential: {
@@ -72,7 +72,7 @@ describe("webauthn-core", () => {
         };
         const result = await webauthn.isConditionalMediationAvailable();
         expect(result).to.be.false;
-      })
+      });
     });
   });
 
@@ -304,48 +304,52 @@ describe("webauthn-core", () => {
         // ignored
       }
 
-      assert.calledOnceWithExactly(global.navigator.credentials.create, {
-        publicKey: {
-          rp: {
-            name: "Spring Security Relying Party",
-            id: "example.localhost",
+      assert.calledOnceWithExactly(
+        global.navigator.credentials.create,
+        match({
+          publicKey: {
+            rp: {
+              name: "Spring Security Relying Party",
+              id: "example.localhost",
+            },
+            user: {
+              name: "user",
+              id: base64url.decode("eatPy60xmXG_58JrIiIBa5wq8Y76c7MD6mnY5vW8yP8"),
+              displayName: "user",
+            },
+            challenge: base64url.decode("s0hBOfkSaVLXdsbyD8jii6t2IjUd-eiTP1Cmeuo1qUo"),
+            pubKeyCredParams: [
+              {
+                type: "public-key",
+                alg: -8,
+              },
+              {
+                type: "public-key",
+                alg: -7,
+              },
+              {
+                type: "public-key",
+                alg: -257,
+              },
+            ],
+            timeout: 300000,
+            excludeCredentials: [
+              {
+                id: base64url.decode("nOsjw8eaaqSwVdTBBYE1FqfGdHs"),
+                type: "public-key",
+                transports: [],
+              },
+            ],
+            authenticatorSelection: {
+              residentKey: "required",
+              userVerification: "preferred",
+            },
+            attestation: "direct",
+            extensions: { credProps: true },
           },
-          user: {
-            name: "user",
-            id: base64url.decode("eatPy60xmXG_58JrIiIBa5wq8Y76c7MD6mnY5vW8yP8"),
-            displayName: "user",
-          },
-          challenge: base64url.decode("s0hBOfkSaVLXdsbyD8jii6t2IjUd-eiTP1Cmeuo1qUo"),
-          pubKeyCredParams: [
-            {
-              type: "public-key",
-              alg: -8,
-            },
-            {
-              type: "public-key",
-              alg: -7,
-            },
-            {
-              type: "public-key",
-              alg: -257,
-            },
-          ],
-          timeout: 300000,
-          excludeCredentials: [
-            {
-              id: base64url.decode("nOsjw8eaaqSwVdTBBYE1FqfGdHs"),
-              type: "public-key",
-              transports: [],
-            },
-          ],
-          authenticatorSelection: {
-            residentKey: "required",
-            userVerification: "preferred",
-          },
-          attestation: "direct",
-          extensions: { credProps: true },
-        },
-      });
+          signal: match.any,
+        }),
+      );
     });
 
     it("throws when the navigator.credentials.create fails", () => {

--- a/spring-security-javascript/test/webauthn-registration.test.js
+++ b/spring-security-javascript/test/webauthn-registration.test.js
@@ -62,30 +62,29 @@ describe("webauthn-registration", () => {
       labelField = {
         value: undefined,
       };
-      deleteForms = []
+      deleteForms = [];
       ui = {
-        getSuccess: function() {
-          return successPopup
+        getSuccess: function () {
+          return successPopup;
         },
-        getError: function() {
-          return errorPopup
+        getError: function () {
+          return errorPopup;
         },
-        getRegisterButton: function() {
-          return registerButton
+        getRegisterButton: function () {
+          return registerButton;
         },
-        getLabelInput: function() {
-          return labelField
+        getLabelInput: function () {
+          return labelField;
         },
-        getDeleteForms: function() {
-          return deleteForms
-        }
+        getDeleteForms: function () {
+          return deleteForms;
+        },
       };
       global.window = {
         location: {
-          href: {}
+          href: {},
         },
       };
-
     });
 
     afterEach(() => {
@@ -189,26 +188,26 @@ describe("webauthn-registration", () => {
           delete global.fetch;
         });
 
-        it("no errors when no forms", async() => {
+        it("no errors when no forms", async () => {
           await setupRegistration({}, "/some/path", ui);
         });
 
-        it("sets up forms for fetch", async() => {
-          const contextPath = '/some/path'
+        it("sets up forms for fetch", async () => {
+          const contextPath = "/some/path";
           const deleteForm = {
             action: `${contextPath}/webauthn/1234`,
             addEventListener: fake(),
-          }
-          deleteForms = [deleteForm]
+          };
+          deleteForms = [deleteForm];
           const headers = {
-            'X-CSRF-TOKEN': 'token',
-          }
+            "X-CSRF-TOKEN": "token",
+          };
           await setupRegistration(headers, contextPath, ui);
           const clickEvent = {
-            preventDefault: fake()
-          }
-          await deleteForm.addEventListener.firstCall.lastArg(clickEvent)
-          assert.calledOnce(clickEvent.preventDefault)
+            preventDefault: fake(),
+          };
+          await deleteForm.addEventListener.firstCall.lastArg(clickEvent);
+          assert.calledOnce(clickEvent.preventDefault);
           assert.calledOnceWithExactly(global.fetch, deleteForm.action, {
             method: "DELETE",
             headers: {
@@ -216,9 +215,9 @@ describe("webauthn-registration", () => {
               ...headers,
             },
           });
-          expect(global.window.location.href).to.equal(`${contextPath}/webauthn/register?success`)
+          expect(global.window.location.href).to.equal(`${contextPath}/webauthn/register?success`);
         });
-      })
+      });
     });
   });
 });


### PR DESCRIPTION
Introduced new `abort-controller.js` module ; it holds a singleton AbortController instance. Whenever `.register()` or `.authenticate()` is called, any in-flight ceremony is cancelled, including conditional mediation-based auth ceremonies.