### PR TITLE
Use HtmlTemplates and default-ui.css in default Register Passkey UI

### DIFF
--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
@@ -105,8 +105,8 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 	private String renderPasskeyRow(CredentialRecord credential, String contextPath, CsrfToken csrfToken) {
 		return HtmlTemplates.fromTemplate(PASSKEY_ROW_TEMPLATE)
 			.withValue("label", credential.getLabel())
-			.withValue("created", credential.getCreated())
-			.withValue("lastUsed", credential.getLastUsed())
+			.withValue("created", credential.getCreated().toString())
+			.withValue("lastUsed", credential.getLastUsed().toString())
 			.withValue("signatureCount", credential.getSignatureCount())
 			.withValue("credentialId", credential.getCredentialId().toBase64UrlString())
 			.withValue("csrfParameterName", csrfToken.getParameterName())
@@ -130,8 +130,7 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 					<meta name="description" content="">
 					<meta name="author" content="">
 					<title>WebAuthn Registration</title>
-					<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-					<link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+					<link href="{{contextPath}}/default-ui.css" rel="stylesheet" />
 					<script type="text/javascript" src="{{contextPath}}/login/webauthn.js"></script>
 					<script type="text/javascript">
 					<!--
@@ -157,20 +156,27 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 					</script>
 				</head>
 				<body>
-					<div class="container">
-						<form class="form-signin" method="post" action="#" onclick="return false">
-							<h2 class="form-signin-heading">WebAuthn Registration</h2>
+					<div class="content">
+						<form class="login-form" method="post" action="#" onclick="return false">
+							<h2>WebAuthn Registration</h2>
 							{{message}}
 							<div id="success" class="alert alert-success" role="alert"></div>
 							<div id="error" class="alert alert-danger" role="alert"></div>
 							<p>
-								<input type="text" id="label" name="label" class="form-control" placeholder="Passkey Label" required autofocus>
+								<label for="label" class="screenreader">Passkey Label</label>
+								<input type="text" id="label" name="label" placeholder="Passkey Label" required autofocus>
 							</p>
-							<button id="register" class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+							<button id="register" class="primary" type="submit">Register</button>
 						</form>
 						<table class="table table-striped">
 							<thead>
-								<tr><th>Label</th><th>Created</th><th>Last Used</th><th>Signature Count</th><th>Delete</th></tr>
+								<tr class="table-header">
+									<th>Label</th>
+									<th>Created</th>
+									<th>Last Used</th>
+									<th>Signature Count</th>
+									<th>Delete</th>
+								</tr>
 							</thead>
 							<tbody>
 								{{passkeys}}
@@ -191,7 +197,7 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 						<form class="delete-form" method="post" action="{{contextPath}}/webauthn/register/{{credentialId}}">
 							<input type="hidden" name="method" value="delete">
 							<input type="hidden" name="{{csrfParameterName}}" value="{{csrfToken}}">
-							<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+							<button class="primary small" type="submit">Delete</button>
 						</form>
 					</td>
 				</tr>

--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
@@ -20,31 +20,28 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.webauthn.api.PublicKeyCredentialUserEntity;
-import org.springframework.security.webauthn.management.PublicKeyCredentialUserEntityRepository;
 import org.springframework.security.webauthn.management.CredentialRecord;
+import org.springframework.security.webauthn.management.PublicKeyCredentialUserEntityRepository;
 import org.springframework.security.webauthn.management.UserCredentialRepository;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.HtmlUtils;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * A {@link jakarta.servlet.Filter} that renders a default WebAuthn registration page.
  *
  * @author Rob Winch
+ * @author Daniel Garnier-Moiroux
  * @since 6.4
  */
 public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequestFilter {
@@ -57,11 +54,11 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 
 	/**
 	 * Creates a new instance.
-	 *
 	 * @param userEntities the {@link PublicKeyCredentialUserEntity}
 	 * @param userCredentials
 	 */
-	public DefaultWebAuthnRegistrationPageGeneratingFilter(PublicKeyCredentialUserEntityRepository userEntities, UserCredentialRepository userCredentials) {
+	public DefaultWebAuthnRegistrationPageGeneratingFilter(PublicKeyCredentialUserEntityRepository userEntities,
+			UserCredentialRepository userCredentials) {
 		Assert.notNull(userEntities, "userEntities cannot be null");
 		Assert.notNull(userCredentials, "userCredentials cannot be null");
 		this.userEntities = userEntities;
@@ -69,144 +66,142 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 	}
 
 	@Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-        throws ServletException, IOException {
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
 		if (!this.matcher.matches(request)) {
 			filterChain.doFilter(request, response);
 			return;
 		}
 
 		boolean success = request.getParameterMap().containsKey("success");
+
 		CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
 		response.setContentType(MediaType.TEXT_HTML_VALUE);
 		response.setStatus(HttpServletResponse.SC_OK);
-		Map<String, Object> context = new HashMap<>();
-		context.put("contextPath", request.getContextPath());
-		context.put("csrfToken", csrfToken.getToken());
-		context.put("csrfParameterName", csrfToken.getParameterName());
-		context.put("csrfHeaderName", csrfToken.getHeaderName());
-		context.put("csrfHeaders", createCsrfHeaders(csrfToken));
-		context.put("message", success ? SUCCESS_MESSAGE : "");
-		context.put("passkeys", passkeyRows(request.getRemoteUser(), context));
-		response.getWriter().write(processTemplate(HTML_TEMPLATE, context));
+		String processedTemplate = HtmlTemplates.fromTemplate(HTML_TEMPLATE)
+			.withValue("contextPath", request.getContextPath())
+			.withRawHtml("message", success ? SUCCESS_MESSAGE : "")
+			.withRawHtml("csrfHeaders", renderCsrfHeader(csrfToken))
+			.withRawHtml("passkeys", passkeyRows(request.getRemoteUser(), request.getContextPath(), csrfToken))
+			.render();
+
+		response.getWriter().write(processedTemplate);
 	}
 
-	private String passkeyRows(String username, Map<String,Object> baseContext) {
+	private String passkeyRows(String username, String contextPath, CsrfToken csrfToken) {
 		PublicKeyCredentialUserEntity userEntity = this.userEntities.findByUsername(username);
-		List<CredentialRecord> credentials = userEntity == null ? Collections.emptyList() : this.userCredentials.findByUserId(userEntity.getId());
+		List<CredentialRecord> credentials = userEntity == null ? Collections.emptyList()
+				: this.userCredentials.findByUserId(userEntity.getId());
 		if (credentials.isEmpty()) {
 			return """
-				<tr><td colspan="5">No Passkeys</td></tr>
-				""";
+					<tr><td colspan="5">No Passkeys</td></tr>
+					""";
 		}
-		String html = "";
-		for (CredentialRecord credential : credentials) {
-			Map<String, Object> context = new HashMap<>(baseContext);
-			context.put("label", HtmlUtils.htmlEscape(credential.getLabel()));
-			context.put("created", credential.getCreated());
-			context.put("lastUsed", credential.getLastUsed());
-			context.put("signatureCount", credential.getSignatureCount());
-			context.put("credentialId", credential.getCredentialId().toBase64UrlString());
-			html += processTemplate(PASSKEY_ROW_TEMPLATE, context);
-		}
-		return html;
+		return credentials.stream()
+			.map(credentialRecord -> renderPasskeyRow(credentialRecord, contextPath, csrfToken))
+			.collect(Collectors.joining("\n"));
 	}
 
-	private String processTemplate(String template, Map<String,Object> context) {
-		for (Map.Entry<String, Object> entry : context.entrySet()) {
-			String pattern = Pattern.quote("${" + entry.getKey() + "}");
-			String value = String.valueOf(entry.getValue());
-			template = template.replaceAll(pattern, value);
-		}
-		return template;
+	private String renderPasskeyRow(CredentialRecord credential, String contextPath, CsrfToken csrfToken) {
+		return HtmlTemplates.fromTemplate(PASSKEY_ROW_TEMPLATE)
+			.withValue("label", credential.getLabel())
+			.withValue("created", credential.getCreated())
+			.withValue("lastUsed", credential.getLastUsed())
+			.withValue("signatureCount", credential.getSignatureCount())
+			.withValue("credentialId", credential.getCredentialId().toBase64UrlString())
+			.withValue("csrfParameterName", csrfToken.getParameterName())
+			.withValue("csrfToken", csrfToken.getToken())
+			.withValue("contextPath", contextPath)
+			.render();
 	}
 
-	private String createCsrfHeaders(CsrfToken csrfToken) {
-		Map<String, Object> headerContext = Map.of("headerName", csrfToken.getHeaderName(), "headerValue",
-				csrfToken.getToken());
-		return processTemplate(CSRF_HEADERS, headerContext);
+	private String renderCsrfHeader(CsrfToken csrfToken) {
+		return HtmlTemplates.fromTemplate(CSRF_HEADERS)
+			.withValue("headerName", csrfToken.getHeaderName())
+			.withValue("headerValue", csrfToken.getToken())
+			.render();
 	}
 
 	private static final String HTML_TEMPLATE = """
-		<html>
-			<head>
-				<meta charset="utf-8">
-				<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-				<meta name="description" content="">
-				<meta name="author" content="">
-				<title>WebAuthn Registration</title>
-				<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-				<link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
-				<script type="text/javascript" src="${contextPath}/login/webauthn.js"></script>
-				<script type="text/javascript">
-				<!--
-					const ui = {
-						getRegisterButton: function() {
-							return document.getElementById('register')
-						},
-						getSuccess: function() {
-							return document.getElementById('success')
-						},
-						getError: function() {
-							return document.getElementById('error')
-						},
-						getLabelInput: function() {
-							return document.getElementById('label')
-						},
-						getDeleteForms: function() {
-							return Array.from(document.getElementsByClassName("delete-form"))
-						},
-					}
-					document.addEventListener("DOMContentLoaded",() => setupRegistration(${csrfHeaders}, "${contextPath}", ui));
-				//-->
-				</script>
-			</head>
-			<body>
-				<div class="container">
-					<form class="form-signin" method="post" action="#" onclick="return false">
-						<h2 class="form-signin-heading">WebAuthn Registration</h2>
-						${message}
-						<div id="success" class="alert alert-success" role="alert"></div>
-						<div id="error" class="alert alert-danger" role="alert"></div>
-						<p>
-							<input type="text" id="label" name="label" class="form-control" placeholder="Passkey Label" required autofocus>
-						</p>
-						<button id="register" class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
-					</form>
-					<table class="table table-striped">
-						<thead>
-							<tr><th>Label</th><th>Created</th><th>Last Used</th><th>Signature Count</th><th>Delete</th></tr>
-						</thead>
-						<tbody>
-							${passkeys}
-						</tbody>
-					</table>
-				</div>
-			</body>
-		</html>
-""";
+			<html>
+				<head>
+					<meta charset="utf-8">
+					<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+					<meta name="description" content="">
+					<meta name="author" content="">
+					<title>WebAuthn Registration</title>
+					<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+					<link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+					<script type="text/javascript" src="{{contextPath}}/login/webauthn.js"></script>
+					<script type="text/javascript">
+					<!--
+						const ui = {
+							getRegisterButton: function() {
+								return document.getElementById('register')
+							},
+							getSuccess: function() {
+								return document.getElementById('success')
+							},
+							getError: function() {
+								return document.getElementById('error')
+							},
+							getLabelInput: function() {
+								return document.getElementById('label')
+							},
+							getDeleteForms: function() {
+								return Array.from(document.getElementsByClassName("delete-form"))
+							},
+						}
+						document.addEventListener("DOMContentLoaded",() => setupRegistration({{csrfHeaders}}, "{{contextPath}}", ui));
+					//-->
+					</script>
+				</head>
+				<body>
+					<div class="container">
+						<form class="form-signin" method="post" action="#" onclick="return false">
+							<h2 class="form-signin-heading">WebAuthn Registration</h2>
+							{{message}}
+							<div id="success" class="alert alert-success" role="alert"></div>
+							<div id="error" class="alert alert-danger" role="alert"></div>
+							<p>
+								<input type="text" id="label" name="label" class="form-control" placeholder="Passkey Label" required autofocus>
+							</p>
+							<button id="register" class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+						</form>
+						<table class="table table-striped">
+							<thead>
+								<tr><th>Label</th><th>Created</th><th>Last Used</th><th>Signature Count</th><th>Delete</th></tr>
+							</thead>
+							<tbody>
+								{{passkeys}}
+							</tbody>
+						</table>
+					</div>
+				</body>
+			</html>
+			""";
 
 	private static final String PASSKEY_ROW_TEMPLATE = """
-		<tr>
-			<td>${label}</td>
-			<td>${created}</td>
-			<td>${lastUsed}</td>
-			<td>${signatureCount}</td>
-			<td>
-				<form class="delete-form" method="post" action="${contextPath}/webauthn/register/${credentialId}">
-					<input type="hidden" name="method" value="delete">
-					<input type="hidden" name="${csrfParameterName}" value="${csrfToken}">
-					<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
-				</form>
-			</td>
-		</tr>
-	""";
+				<tr>
+					<td>{{label}}</td>
+					<td>{{created}}</td>
+					<td>{{lastUsed}}</td>
+					<td>{{signatureCount}}</td>
+					<td>
+						<form class="delete-form" method="post" action="{{contextPath}}/webauthn/register/{{credentialId}}">
+							<input type="hidden" name="method" value="delete">
+							<input type="hidden" name="{{csrfParameterName}}" value="{{csrfToken}}">
+							<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+						</form>
+					</td>
+				</tr>
+			""";
 
 	private static final String SUCCESS_MESSAGE = """
- 		<div class="alert alert-success" role="alert">Success!</div>
-	""";
+					<div class="alert alert-success" role="alert">Success!</div>
+			""";
 
 	private static final String CSRF_HEADERS = """
-			{"${headerName}" : "${headerValue}"}""";
+			{"{{headerName}}" : "{{headerValue}}"}""";
 
 }

--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
@@ -94,7 +94,7 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 				: this.userCredentials.findByUserId(userEntity.getId());
 		if (credentials.isEmpty()) {
 			return """
-					<tr><td colspan="5">No Passkeys</td></tr>
+										<tr><td colspan="5">No Passkeys</td></tr>
 					""";
 		}
 		return credentials.stream()
@@ -157,9 +157,9 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 				</head>
 				<body>
 					<div class="content">
-						<form class="login-form" method="post" action="#" onclick="return false">
-							<h2>WebAuthn Registration</h2>
-							{{message}}
+						<h2 class="center">WebAuthn Registration</h2>
+						<form class="default-form" method="post" action="#" onclick="return false">
+			{{message}}
 							<div id="success" class="alert alert-success" role="alert"></div>
 							<div id="error" class="alert alert-danger" role="alert"></div>
 							<p>
@@ -179,7 +179,7 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 								</tr>
 							</thead>
 							<tbody>
-								{{passkeys}}
+			{{passkeys}}
 							</tbody>
 						</table>
 					</div>
@@ -188,23 +188,23 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 			""";
 
 	private static final String PASSKEY_ROW_TEMPLATE = """
-				<tr>
-					<td>{{label}}</td>
-					<td>{{created}}</td>
-					<td>{{lastUsed}}</td>
-					<td>{{signatureCount}}</td>
-					<td>
-						<form class="delete-form" method="post" action="{{contextPath}}/webauthn/register/{{credentialId}}">
-							<input type="hidden" name="method" value="delete">
-							<input type="hidden" name="{{csrfParameterName}}" value="{{csrfToken}}">
-							<button class="primary small" type="submit">Delete</button>
-						</form>
-					</td>
-				</tr>
+								<tr class="v-middle">
+									<td>{{label}}</td>
+									<td>{{created}}</td>
+									<td>{{lastUsed}}</td>
+									<td class="center">{{signatureCount}}</td>
+									<td>
+										<form class="delete-form" method="post" action="{{contextPath}}/webauthn/register/{{credentialId}}">
+											<input type="hidden" name="method" value="delete">
+											<input type="hidden" name="{{csrfParameterName}}" value="{{csrfToken}}">
+											<button class="primary small" type="submit">Delete</button>
+										</form>
+									</td>
+								</tr>
 			""";
 
 	private static final String SUCCESS_MESSAGE = """
-					<div class="alert alert-success" role="alert">Success!</div>
+							<div class="alert alert-success" role="alert">Success!</div>
 			""";
 
 	private static final String CSRF_HEADERS = """

--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
@@ -33,6 +33,11 @@ import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -105,14 +110,20 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 	private String renderPasskeyRow(CredentialRecord credential, String contextPath, CsrfToken csrfToken) {
 		return HtmlTemplates.fromTemplate(PASSKEY_ROW_TEMPLATE)
 			.withValue("label", credential.getLabel())
-			.withValue("created", credential.getCreated().toString())
-			.withValue("lastUsed", credential.getLastUsed().toString())
+			.withValue("created", formatInstant(credential.getCreated()))
+			.withValue("lastUsed", formatInstant(credential.getLastUsed()))
 			.withValue("signatureCount", credential.getSignatureCount())
 			.withValue("credentialId", credential.getCredentialId().toBase64UrlString())
 			.withValue("csrfParameterName", csrfToken.getParameterName())
 			.withValue("csrfToken", csrfToken.getToken())
 			.withValue("contextPath", contextPath)
 			.render();
+	}
+
+	private static String formatInstant(Instant created) {
+		return ZonedDateTime.ofInstant(created, ZoneId.of("UTC"))
+			.truncatedTo(ChronoUnit.SECONDS)
+			.format(DateTimeFormatter.ISO_INSTANT);
 	}
 
 	private String renderCsrfHeader(CsrfToken csrfToken) {

--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/HtmlTemplates.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/HtmlTemplates.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.webauthn.registration;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Render HTML templates using string substitution. Intended for internal use. Variables
+ * can be templated using double curly-braces: {@code {{name}}}.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @since 6.4
+ * @see org.springframework.security.web.authentication.ui.HtmlTemplates
+ */
+final class HtmlTemplates {
+
+	private HtmlTemplates() {
+	}
+
+	static HtmlTemplates.Builder fromTemplate(String template) {
+		return new HtmlTemplates.Builder(template);
+	}
+
+	static final class Builder {
+
+		private final String template;
+
+		private final Map<String, String> values = new HashMap<>();
+
+		private Builder(String template) {
+			this.template = template;
+		}
+
+		/**
+		 * HTML-escape, and inject value {@code value} in every {@code {{key}}}
+		 * placeholder.
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		HtmlTemplates.Builder withValue(String key, Object value) {
+			Assert.notNull(value, "value cannot be null");
+			this.values.put(key, HtmlUtils.htmlEscape(value.toString()));
+			return this;
+		}
+
+		/**
+		 * Inject value {@code value} in every {@code {{key}}} placeholder without
+		 * HTML-escaping. Useful for injecting "sub-templates".
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		HtmlTemplates.Builder withRawHtml(String key, String value) {
+			if (!value.isEmpty() && value.charAt(value.length() - 1) == '\n') {
+				value = value.substring(0, value.length() - 1);
+			}
+			this.values.put(key, value);
+			return this;
+		}
+
+		/**
+		 * Render the template. All placeholders MUST have a corresponding value. If a
+		 * placeholder does not have a corresponding value, throws
+		 * {@link IllegalStateException}.
+		 * @return the rendered template
+		 */
+		String render() {
+			String template = this.template;
+			for (String key : this.values.keySet()) {
+				String pattern = Pattern.quote("{{" + key + "}}");
+				template = template.replaceAll(pattern, this.values.get(key));
+			}
+
+			String unusedPlaceholders = Pattern.compile("\\{\\{([a-zA-Z0-9]+)}}")
+				.matcher(template)
+				.results()
+				.map((result) -> result.group(1))
+				.collect(Collectors.joining(", "));
+			if (StringUtils.hasLength(unusedPlaceholders)) {
+				throw new IllegalStateException("Unused placeholders in template: [%s]".formatted(unusedPlaceholders));
+			}
+
+			return template;
+		}
+
+	}
+
+}

--- a/spring-security-webauthn/src/main/resources/org/springframework/security/default-ui.css
+++ b/spring-security-webauthn/src/main/resources/org/springframework/security/default-ui.css
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* General layout */
+body {
+    font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: #eee;
+    padding: 40px 0;
+    margin: 0;
+    line-height: 1.5;
+}
+
+h2 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 2rem;
+    font-weight: 500;
+    line-height: 2rem;
+}
+
+.content {
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: 15px;
+    padding-left: 15px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+@media (min-width: 800px) {
+    .content {
+        max-width: 760px;
+    }
+}
+
+/* Components */
+a,
+a:visited {
+    text-decoration: none;
+    color: #06f;
+}
+
+a:hover {
+    text-decoration: underline;
+    color: #003c97;
+}
+
+input[type="text"],
+input[type="password"] {
+    height: auto;
+    width: 100%;
+    font-size: 1rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
+}
+
+button {
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+    line-height: 1.5;
+    border: none;
+    border-radius: 0.1rem;
+    width: 100%;
+    cursor: pointer;
+}
+
+button.primary {
+    color: #fff;
+    background-color: #06f;
+}
+
+button.small {
+    padding: .25rem .5rem;
+    font-size: .875rem;
+    line-height: 1.5;
+}
+
+.alert {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+    border-radius: 0.1rem;
+    width: 100%;
+    box-sizing: border-box;
+    border-width: 1px;
+    border-style: solid;
+}
+
+.alert.alert-danger {
+    color: #6b1922;
+    background-color: #f7d5d7;
+    border-color: #eab6bb;
+}
+
+.alert.alert-success {
+    color: #145222;
+    background-color: #d1f0d9;
+    border-color: #c2ebcb;
+}
+
+.screenreader {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+}
+
+table {
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: 2rem;
+    border-collapse: collapse;
+}
+
+.table-striped th {
+    padding: .75rem;
+}
+
+.table-striped tr:nth-of-type(2n + 1) {
+    background-color: #e1e1e1;
+}
+
+.table-striped > thead > tr:first-child {
+    background-color: inherit;
+}
+
+td {
+    padding: 0.75rem;
+    vertical-align: top;
+}
+
+/* Login / logout layouts */
+.login-form,
+.logout-form,
+.default-form {
+    max-width: 340px;
+    padding: 0 15px 15px 15px;
+    margin: 0 auto 2rem auto;
+    box-sizing: border-box;
+}

--- a/spring-security-webauthn/src/main/resources/org/springframework/security/default-ui.css
+++ b/spring-security-webauthn/src/main/resources/org/springframework/security/default-ui.css
@@ -46,6 +46,14 @@ h2 {
     }
 }
 
+.v-middle {
+    vertical-align: middle;
+}
+
+.center {
+    text-align: center;
+}
+
 /* Components */
 a,
 a:visited {
@@ -143,6 +151,10 @@ table {
 td {
     padding: 0.75rem;
     vertical-align: top;
+}
+
+tr.v-middle > td {
+    vertical-align: middle;
 }
 
 /* Login / logout layouts */

--- a/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -131,8 +131,8 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.build();
 
 		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential()
-			.created(LocalDateTime.of(2024, 9, 17, 10, 10, 42).toInstant(ZoneOffset.UTC))
-			.lastUsed(LocalDateTime.of(2024, 9, 18, 11, 11, 42).toInstant(ZoneOffset.UTC))
+			.created(LocalDateTime.of(2024, 9, 17, 10, 10, 42, 999_999_999).toInstant(ZoneOffset.UTC))
+			.lastUsed(LocalDateTime.of(2024, 9, 18, 11, 11, 42, 999_999_999).toInstant(ZoneOffset.UTC))
 			.build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
@@ -197,8 +197,8 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 										<tbody>
 											<tr class="v-middle">
 												<td>label</td>
-												<td>%s</td>
-												<td>%s</td>
+												<td>2024-09-17T10:10:42Z</td>
+												<td>2024-09-18T11:11:42Z</td>
 												<td class="center">0</td>
 												<td>
 													<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
@@ -213,8 +213,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 								</div>
 							</body>
 						</html>
-						"""
-					.formatted(credential.getCreated().toString(), credential.getLastUsed().toString()));
+						""");
 	}
 
 	@Test

--- a/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -47,9 +47,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @ExtendWith(MockitoExtension.class)
@@ -175,9 +173,9 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 							</head>
 							<body>
 								<div class="content">
-									<form class="login-form" method="post" action="#" onclick="return false">
-										<h2>WebAuthn Registration</h2>
-									\t
+									<h2 class="center">WebAuthn Registration</h2>
+									<form class="default-form" method="post" action="#" onclick="return false">
+
 										<div id="success" class="alert alert-success" role="alert"></div>
 										<div id="error" class="alert alert-danger" role="alert"></div>
 										<p>
@@ -197,19 +195,19 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 											</tr>
 										</thead>
 										<tbody>
-												<tr>
-								<td>label</td>
-								<td>%s</td>
-								<td>%s</td>
-								<td>0</td>
-								<td>
-									<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
-										<input type="hidden" name="method" value="delete">
-										<input type="hidden" name="_csrf" value="CSRF_TOKEN">
-										<button class="primary small" type="submit">Delete</button>
-									</form>
-								</td>
-							</tr>
+											<tr class="v-middle">
+												<td>label</td>
+												<td>%s</td>
+												<td>%s</td>
+												<td class="center">0</td>
+												<td>
+													<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
+														<input type="hidden" name="method" value="delete">
+														<input type="hidden" name="_csrf" value="CSRF_TOKEN">
+														<button class="primary small" type="submit">Delete</button>
+													</form>
+												</td>
+											</tr>
 										</tbody>
 									</table>
 								</div>

--- a/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -39,6 +39,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.util.HtmlUtils;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -97,7 +99,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 				<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
 					<input type="hidden" name="method" value="delete">
 					<input type="hidden" name="_csrf" value="CSRF_TOKEN">
-					<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+					<button class="primary small" type="submit">Delete</button>
 				</form>""".replaceAll("\\s", ""));
 	}
 
@@ -129,15 +131,14 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.id(Bytes.random())
 			.displayName("User")
 			.build();
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
+
+		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential()
+			.created(LocalDateTime.of(2024, 9, 17, 10, 10, 42).toInstant(ZoneOffset.UTC))
+			.lastUsed(LocalDateTime.of(2024, 9, 18, 11, 11, 42).toInstant(ZoneOffset.UTC))
+			.build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest());
-		assertThat(body).contains(credential.getLabel());
-		assertThat(body).contains(credential.getCreated().toString());
-		assertThat(body).contains(credential.getLastUsed().toString());
-		assertThat(body).contains(String.valueOf(credential.getSignatureCount()));
-		assertThat(body).contains(credential.getCredentialId().toBase64UrlString());
 		assertThat(body).isEqualTo(
 				"""
 						<html>
@@ -147,8 +148,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 								<meta name="description" content="">
 								<meta name="author" content="">
 								<title>WebAuthn Registration</title>
-								<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-								<link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+								<link href="/default-ui.css" rel="stylesheet" />
 								<script type="text/javascript" src="/login/webauthn.js"></script>
 								<script type="text/javascript">
 								<!--
@@ -174,20 +174,27 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 								</script>
 							</head>
 							<body>
-								<div class="container">
-									<form class="form-signin" method="post" action="#" onclick="return false">
-										<h2 class="form-signin-heading">WebAuthn Registration</h2>
+								<div class="content">
+									<form class="login-form" method="post" action="#" onclick="return false">
+										<h2>WebAuthn Registration</h2>
 									\t
 										<div id="success" class="alert alert-success" role="alert"></div>
 										<div id="error" class="alert alert-danger" role="alert"></div>
 										<p>
-											<input type="text" id="label" name="label" class="form-control" placeholder="Passkey Label" required autofocus>
+											<label for="label" class="screenreader">Passkey Label</label>
+											<input type="text" id="label" name="label" placeholder="Passkey Label" required autofocus>
 										</p>
-										<button id="register" class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+										<button id="register" class="primary" type="submit">Register</button>
 									</form>
 									<table class="table table-striped">
 										<thead>
-											<tr><th>Label</th><th>Created</th><th>Last Used</th><th>Signature Count</th><th>Delete</th></tr>
+											<tr class="table-header">
+												<th>Label</th>
+												<th>Created</th>
+												<th>Last Used</th>
+												<th>Signature Count</th>
+												<th>Delete</th>
+											</tr>
 										</thead>
 										<tbody>
 												<tr>
@@ -199,7 +206,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 									<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
 										<input type="hidden" name="method" value="delete">
 										<input type="hidden" name="_csrf" value="CSRF_TOKEN">
-										<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+										<button class="primary small" type="submit">Delete</button>
 									</form>
 								</td>
 							</tr>
@@ -209,7 +216,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 							</body>
 						</html>
 						"""
-					.formatted(credential.getCreated(), credential.getLastUsed()));
+					.formatted(credential.getCreated().toString(), credential.getLastUsed().toString()));
 	}
 
 	@Test

--- a/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -25,10 +25,10 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
-import org.springframework.security.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
-import org.springframework.security.webauthn.api.TestCredentialRecord;
 import org.springframework.security.webauthn.api.Bytes;
+import org.springframework.security.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
 import org.springframework.security.webauthn.api.PublicKeyCredentialUserEntity;
+import org.springframework.security.webauthn.api.TestCredentialRecord;
 import org.springframework.security.webauthn.management.ImmutableCredentialRecord;
 import org.springframework.security.webauthn.management.PublicKeyCredentialUserEntityRepository;
 import org.springframework.security.webauthn.management.UserCredentialRepository;
@@ -62,19 +62,19 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 	@Test
 	void constructorWhenNullUserEntities() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new DefaultWebAuthnRegistrationPageGeneratingFilter(null, this.userCredentials))
-				.withMessage("userEntities cannot be null");
+			.isThrownBy(() -> new DefaultWebAuthnRegistrationPageGeneratingFilter(null, this.userCredentials))
+			.withMessage("userEntities cannot be null");
 	}
 
 	@Test
 	void constructorWhenNullUserCredentials() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new DefaultWebAuthnRegistrationPageGeneratingFilter(this.userEntities, null))
-				.withMessage("userCredentials cannot be null");
+			.isThrownBy(() -> new DefaultWebAuthnRegistrationPageGeneratingFilter(this.userEntities, null))
+			.withMessage("userCredentials cannot be null");
 	}
 
 	@Test
-	void doFilterWhenNotMatchThenNoInteractions() throws Exception{
+	void doFilterWhenNotMatchThenNoInteractions() throws Exception {
 		MockMvc mockMvc = mockMvc();
 		mockMvc.perform(get("/not-match"));
 
@@ -84,20 +84,21 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 	@Test
 	void doFilterThenCsrfDataAttrsPresent() throws Exception {
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
+			.build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
-		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(TestCredentialRecord.userCredential().build()));
+		when(this.userCredentials.findByUserId(userEntity.getId()))
+			.thenReturn(Arrays.asList(TestCredentialRecord.userCredential().build()));
 		String body = bodyAsString(matchingRequest());
 		assertThat(body).contains("setupRegistration({\"X-CSRF-TOKEN\" : \"CSRF_TOKEN\"}");
 		assertThat(body.replaceAll("\\s", "")).contains("""
-			<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
-				<input type="hidden" name="method" value="delete">
-				<input type="hidden" name="_csrf" value="CSRF_TOKEN">
-				<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
-			</form>""".replaceAll("\\s", ""));
+				<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
+					<input type="hidden" name="method" value="delete">
+					<input type="hidden" name="_csrf" value="CSRF_TOKEN">
+					<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+				</form>""".replaceAll("\\s", ""));
 	}
 
 	@Test
@@ -110,10 +111,10 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 	@Test
 	void doFilterWhenNoCredentialsThenNoResults() throws Exception {
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
+			.build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Collections.emptyList());
 		String body = bodyAsString(matchingRequest());
@@ -124,10 +125,10 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 	@Test
 	void doFilterWhenResultsThenDisplayed() throws Exception {
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
+			.build();
 		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
@@ -137,6 +138,78 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 		assertThat(body).contains(credential.getLastUsed().toString());
 		assertThat(body).contains(String.valueOf(credential.getSignatureCount()));
 		assertThat(body).contains(credential.getCredentialId().toBase64UrlString());
+		assertThat(body).isEqualTo(
+				"""
+						<html>
+							<head>
+								<meta charset="utf-8">
+								<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+								<meta name="description" content="">
+								<meta name="author" content="">
+								<title>WebAuthn Registration</title>
+								<link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+								<link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+								<script type="text/javascript" src="/login/webauthn.js"></script>
+								<script type="text/javascript">
+								<!--
+									const ui = {
+										getRegisterButton: function() {
+											return document.getElementById('register')
+										},
+										getSuccess: function() {
+											return document.getElementById('success')
+										},
+										getError: function() {
+											return document.getElementById('error')
+										},
+										getLabelInput: function() {
+											return document.getElementById('label')
+										},
+										getDeleteForms: function() {
+											return Array.from(document.getElementsByClassName("delete-form"))
+										},
+									}
+									document.addEventListener("DOMContentLoaded",() => setupRegistration({"X-CSRF-TOKEN" : "CSRF_TOKEN"}, "", ui));
+								//-->
+								</script>
+							</head>
+							<body>
+								<div class="container">
+									<form class="form-signin" method="post" action="#" onclick="return false">
+										<h2 class="form-signin-heading">WebAuthn Registration</h2>
+									\t
+										<div id="success" class="alert alert-success" role="alert"></div>
+										<div id="error" class="alert alert-danger" role="alert"></div>
+										<p>
+											<input type="text" id="label" name="label" class="form-control" placeholder="Passkey Label" required autofocus>
+										</p>
+										<button id="register" class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+									</form>
+									<table class="table table-striped">
+										<thead>
+											<tr><th>Label</th><th>Created</th><th>Last Used</th><th>Signature Count</th><th>Delete</th></tr>
+										</thead>
+										<tbody>
+												<tr>
+								<td>label</td>
+								<td>%s</td>
+								<td>%s</td>
+								<td>0</td>
+								<td>
+									<form class="delete-form" method="post" action="/webauthn/register/NauGCN7bZ5jEBwThcde51g">
+										<input type="hidden" name="method" value="delete">
+										<input type="hidden" name="_csrf" value="CSRF_TOKEN">
+										<button class="btn btn-sm btn-primary btn-block" type="submit">Delete</button>
+									</form>
+								</td>
+							</tr>
+										</tbody>
+									</table>
+								</div>
+							</body>
+						</html>
+						"""
+					.formatted(credential.getCreated(), credential.getLastUsed()));
 	}
 
 	@Test
@@ -145,13 +218,11 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 		String htmlEncodedLabel = HtmlUtils.htmlEscape(label);
 		assertThat(label).isNotEqualTo(htmlEncodedLabel);
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential()
-			.label(label)
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
 			.build();
+		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().label(label).build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest());
@@ -174,25 +245,26 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 	@Test
 	void doFilterWhenContextEmptyThenUrlsEmptyPrefix() throws Exception {
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
+			.build();
 		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest());
 		assertThat(body).contains("<script type=\"text/javascript\" src=\"/login/webauthn.js\"></script>");
-		assertThat(body).contains("document.addEventListener(\"DOMContentLoaded\",() => setupRegistration({\"X-CSRF-TOKEN\" : \"CSRF_TOKEN\"}, \"\",");
+		assertThat(body).contains(
+				"document.addEventListener(\"DOMContentLoaded\",() => setupRegistration({\"X-CSRF-TOKEN\" : \"CSRF_TOKEN\"}, \"\",");
 	}
 
 	@Test
 	void doFilterWhenContextNotEmptyThenUrlsPrefixed() throws Exception {
 		PublicKeyCredentialUserEntity userEntity = ImmutablePublicKeyCredentialUserEntity.builder()
-				.name("user")
-				.id(Bytes.random())
-				.displayName("User")
-				.build();
+			.name("user")
+			.id(Bytes.random())
+			.displayName("User")
+			.build();
 		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
 		when(this.userEntities.findByUsername(any())).thenReturn(userEntity);
 		when(this.userCredentials.findByUserId(userEntity.getId())).thenReturn(Arrays.asList(credential));
@@ -216,15 +288,14 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 
 	private MockHttpServletRequestBuilder matchingRequest(String contextPath) {
 		DefaultCsrfToken token = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "CSRF_TOKEN");
-		return get(contextPath + "/webauthn/register")
-			.contextPath(contextPath)
+		return get(contextPath + "/webauthn/register").contextPath(contextPath)
 			.requestAttr(CsrfToken.class.getName(), token);
 	}
 
 	private MockMvc mockMvc() {
-		return MockMvcBuilders
-				.standaloneSetup(new Object())
-				.addFilter(new DefaultWebAuthnRegistrationPageGeneratingFilter(this.userEntities, this.userCredentials))
-				.build();
+		return MockMvcBuilders.standaloneSetup(new Object())
+			.addFilter(new DefaultWebAuthnRegistrationPageGeneratingFilter(this.userEntities, this.userCredentials))
+			.build();
 	}
+
 }


### PR DESCRIPTION
This PR leverages the work on `HtmlTemplates` and `default-ui.css` in the default UI for registering passkeys.

There are changes to `default-ui.css` to make this work, so I included it in this project. It will have to be backported to Spring Security when this is merged.

I also too the liberty of formatting the create / use dates of passkeys to drop nanoseconds from the UI.

Current look-and-feel:

![Screenshot 2024-09-18 at 14 48 36](https://github.com/user-attachments/assets/6118c330-1ae5-4225-b8d1-11f02aa8a7c4)
