### PR TITLE
Handle success popup display/hiding in Javascript

### DIFF
--- a/spring-security-javascript/lib/webauthn-registration.js
+++ b/spring-security-javascript/lib/webauthn-registration.js
@@ -53,8 +53,8 @@ function resetPopups(ui) {
 
 /**
  *
- * @param headers
- * @param contextPath
+ * @param headers headers added to the credentials creation POST request, typically CSRF
+ * @param contextPath the contextPath from which the app is served
  * @param ui contains getRegisterButton(), getSuccess(), getError(), getLabelInput(), getDeleteForms()
  * @returns {Promise<void>}
  */

--- a/spring-security-javascript/lib/webauthn-registration.js
+++ b/spring-security-javascript/lib/webauthn-registration.js
@@ -51,6 +51,20 @@ function resetPopups(ui) {
   setVisibility(error, false);
 }
 
+async function submitDeleteForm(contextPath, form, headers) {
+  const options = {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  };
+  await fetch(form.action, options);
+  // TODO: error handling
+  window.location.href = `${contextPath}/webauthn/register?success`;
+  return false;
+}
+
 /**
  *
  * @param headers headers added to the credentials creation POST request, typically CSRF
@@ -88,18 +102,4 @@ export async function setupRegistration(headers, contextPath, ui) {
       submitDeleteForm(contextPath, form, headers);
     }),
   );
-}
-
-async function submitDeleteForm(contextPath, form, headers) {
-  const options = {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      ...headers,
-    },
-  };
-  await fetch(form.action, options);
-  // TODO: error handling
-  window.location.href = `${contextPath}/webauthn/register?success`;
-  return false;
 }

--- a/spring-security-javascript/lib/webauthn-registration.js
+++ b/spring-security-javascript/lib/webauthn-registration.js
@@ -24,13 +24,24 @@ function setVisibility(element, value) {
   }
   element.style.display = value ? "block" : "none";
 }
+
 function setError(ui, msg) {
+  resetPopups(ui);
   const error = ui.getError();
   if (!error) {
     return;
   }
-  setVisibility(error, true);
   error.textContent = msg;
+  setVisibility(error, true);
+}
+
+function setSuccess(ui) {
+  resetPopups(ui);
+  const success = ui.getSuccess();
+  if (!success) {
+    return;
+  }
+  setVisibility(success, true);
 }
 
 function resetPopups(ui) {
@@ -38,12 +49,6 @@ function resetPopups(ui) {
   const error = ui.getError();
   setVisibility(success, false);
   setVisibility(error, false);
-  if (!!success) {
-    success.textContent = "";
-  }
-  if (!!error) {
-    error.textContent = "";
-  }
 }
 
 /**
@@ -54,12 +59,16 @@ function resetPopups(ui) {
  * @returns {Promise<void>}
  */
 export async function setupRegistration(headers, contextPath, ui) {
-  // TODO: show success
   resetPopups(ui);
 
   if (!window.PublicKeyCredential) {
     setError(ui, "WebAuthn is not supported");
     return;
+  }
+
+  const queryString = new URLSearchParams(window.location.search);
+  if (queryString.has("success")) {
+    setSuccess(ui);
   }
 
   ui.getRegisterButton().addEventListener("click", async () => {
@@ -90,6 +99,7 @@ async function submitDeleteForm(contextPath, form, headers) {
     },
   };
   await fetch(form.action, options);
+  // TODO: error handling
   window.location.href = `${contextPath}/webauthn/register?success`;
   return false;
 }

--- a/spring-security-javascript/test/webauthn-registration.test.js
+++ b/spring-security-javascript/test/webauthn-registration.test.js
@@ -130,6 +130,19 @@ describe("webauthn-registration", () => {
         assert.calledOnceWithMatch(registerButton.addEventListener, "click", match.typeOf("function"));
       });
 
+      describe(`when the query string contains "success"`, () => {
+        beforeEach(() => {
+          global.window.location.search = "?success&continue=true";
+        });
+
+        it("shows the success popup", async () => {
+          await setupRegistration({}, "/", ui);
+
+          expect(successPopup).to.be.visible;
+          expect(errorPopup).to.be.hidden;
+        });
+      });
+
       describe("when the register button is clicked", () => {
         const headers = { "x-header": "value" };
         const contextPath = "/some/path";
@@ -138,7 +151,7 @@ describe("webauthn-registration", () => {
           await setupRegistration(headers, contextPath, ui);
         });
 
-        it("clears the messages", async () => {
+        it("hides all the popups", async () => {
           successPopup.textContent = "dummy-content";
           successPopup.style.display = "block";
           errorPopup.textContent = "dummy-content";
@@ -146,9 +159,7 @@ describe("webauthn-registration", () => {
 
           await registerButton.addEventListener.firstCall.lastArg();
 
-          expect(successPopup.textContent).to.equal("");
           expect(successPopup).to.be.hidden;
-          expect(errorPopup.textContent).to.equal("");
           expect(errorPopup).to.be.hidden;
         });
 
@@ -195,7 +206,6 @@ describe("webauthn-registration", () => {
         it("sets up forms for fetch", async () => {
           const contextPath = "/some/path";
           const deleteForm = {
-            action: `${contextPath}/webauthn/1234`,
             addEventListener: fake(),
           };
           deleteForms = [deleteForm];

--- a/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
+++ b/spring-security-webauthn/src/main/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilter.java
@@ -78,14 +78,11 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 			return;
 		}
 
-		boolean success = request.getParameterMap().containsKey("success");
-
 		CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
 		response.setContentType(MediaType.TEXT_HTML_VALUE);
 		response.setStatus(HttpServletResponse.SC_OK);
 		String processedTemplate = HtmlTemplates.fromTemplate(HTML_TEMPLATE)
 			.withValue("contextPath", request.getContextPath())
-			.withRawHtml("message", success ? SUCCESS_MESSAGE : "")
 			.withRawHtml("csrfHeaders", renderCsrfHeader(csrfToken))
 			.withRawHtml("passkeys", passkeyRows(request.getRemoteUser(), request.getContextPath(), csrfToken))
 			.render();
@@ -170,8 +167,7 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 					<div class="content">
 						<h2 class="center">WebAuthn Registration</h2>
 						<form class="default-form" method="post" action="#" onclick="return false">
-			{{message}}
-							<div id="success" class="alert alert-success" role="alert"></div>
+							<div id="success" class="alert alert-success" role="alert">Success!</div>
 							<div id="error" class="alert alert-danger" role="alert"></div>
 							<p>
 								<label for="label" class="screenreader">Passkey Label</label>
@@ -212,10 +208,6 @@ public class DefaultWebAuthnRegistrationPageGeneratingFilter extends OncePerRequ
 										</form>
 									</td>
 								</tr>
-			""";
-
-	private static final String SUCCESS_MESSAGE = """
-							<div class="alert alert-success" role="alert">Success!</div>
 			""";
 
 	private static final String CSRF_HEADERS = """

--- a/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/spring-security-webauthn/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -175,8 +175,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 								<div class="content">
 									<h2 class="center">WebAuthn Registration</h2>
 									<form class="default-form" method="post" action="#" onclick="return false">
-
-										<div id="success" class="alert alert-success" role="alert"></div>
+										<div id="success" class="alert alert-success" role="alert">Success!</div>
 										<div id="error" class="alert alert-danger" role="alert"></div>
 										<p>
 											<label for="label" class="screenreader">Passkey Label</label>
@@ -232,18 +231,6 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 		String body = bodyAsString(matchingRequest());
 		assertThat(body).doesNotContain(credential.getLabel());
 		assertThat(body).contains(htmlEncodedLabel);
-	}
-
-	@Test
-	void doFilterWhenSuccessThenMessage() throws Exception {
-		String body = bodyAsString(matchingRequest().param("success", ""));
-		assertThat(body).contains("Success!");
-	}
-
-	@Test
-	void doFilterWhenNotSuccessThenNoMessage() throws Exception {
-		String body = bodyAsString(matchingRequest());
-		assertThat(body).doesNotContain("Success!");
 	}
 
 	@Test


### PR DESCRIPTION
This is consistent with how we handle the error popup.

Added a couple of refactor commits, with JSdoc updates + reordering methods, only the first commit brings meaningful changes.